### PR TITLE
Show attempts

### DIFF
--- a/client/src/components/Header.tsx
+++ b/client/src/components/Header.tsx
@@ -34,13 +34,35 @@ const Header = () => {
       <Flex bg="gray.200" w="100%" position="sticky" zIndex="1" p={4}>
         <TabList>
           <Tab onClick={() => game.jumpToLevel(0)}>Level 1</Tab>
-          <Tab isDisabled={!game.hasSeenLevel(0)} onClick={() => game.jumpToLevel(1)}>Level 2</Tab>
-          <Tab isDisabled={!game.hasSeenLevel(1)} onClick={() => game.jumpToLevel(2)}>Level 3</Tab>
-          <Tab isDisabled={!game.hasSeenLevel(2)} onClick={() => game.jumpToLevel(3)}>Level 4</Tab>
-          <Tab isDisabled={!game.hasSeenLevel(3)} onClick={() => game.jumpToLevel(4)}>Level 5</Tab>
+          <Tab
+            isDisabled={!game.hasSeenLevel(0)}
+            onClick={() => game.jumpToLevel(1)}
+          >
+            Level 2
+          </Tab>
+          <Tab
+            isDisabled={!game.hasSeenLevel(1)}
+            onClick={() => game.jumpToLevel(2)}
+          >
+            Level 3
+          </Tab>
+          <Tab
+            isDisabled={!game.hasSeenLevel(2)}
+            onClick={() => game.jumpToLevel(3)}
+          >
+            Level 4
+          </Tab>
+          <Tab
+            isDisabled={!game.hasSeenLevel(3)}
+            onClick={() => game.jumpToLevel(4)}
+          >
+            Level 5
+          </Tab>
         </TabList>
         <Spacer />
-        <Button onClick={game.restartLevel} mr={4}>Restart</Button>
+        <Button onClick={game.restartLevel} mr={4}>
+          Restart
+        </Button>
         <Button colorScheme="red" onClick={routeChange}>
           Quit
         </Button>

--- a/client/src/components/Level1.tsx
+++ b/client/src/components/Level1.tsx
@@ -7,6 +7,7 @@ const Level1 = () => {
       headingText="Level 1: Sorting Demonstration"
       showInstructions={true}
       showInput={false}
+      showAttempts={false}
     />
   );
 };

--- a/client/src/components/Level2.tsx
+++ b/client/src/components/Level2.tsx
@@ -7,6 +7,7 @@ const Level2 = () => {
       headingText="Level 2: User-Driven Sort with Instructions"
       showInstructions={true}
       showInput={true}
+      showAttempts={true}
     />
   );
 };

--- a/client/src/components/Level3.tsx
+++ b/client/src/components/Level3.tsx
@@ -7,6 +7,7 @@ const Level3 = () => {
       headingText="Level 3: User-Driven Sort"
       showInstructions={false}
       showInput={true}
+      showAttempts={true}
     />
   );
 };

--- a/client/src/components/Level4.tsx
+++ b/client/src/components/Level4.tsx
@@ -7,6 +7,7 @@ const Level4 = () => {
       headingText="Level 4: Large User-Driven Sort"
       showInstructions={false}
       showInput={true}
+      showAttempts={true}
     />
   );
 };

--- a/client/src/components/Level5.tsx
+++ b/client/src/components/Level5.tsx
@@ -7,6 +7,7 @@ const Level5 = () => {
       headingText="Level 5: Extra-Large User-Driven Sort"
       showInstructions={false}
       showInput={true}
+      showAttempts={true}
     />
   );
 };

--- a/client/src/components/LevelLayout.tsx
+++ b/client/src/components/LevelLayout.tsx
@@ -64,7 +64,7 @@ const LevelLayout: React.FC<Props> = ({
             p={4}
             borderRadius="lg"
           >
-           <Text>Remaining Attempts: {game.attempts}/3 </Text>
+           <Text>Remaining Attempts: {3-game.attempts}/3 </Text>
         </Box>}
       </Flex>
     </Box>

--- a/client/src/components/LevelLayout.tsx
+++ b/client/src/components/LevelLayout.tsx
@@ -5,6 +5,7 @@ import {
   Flex,
   Heading,
   Spacer,
+  Text,
 } from "@chakra-ui/react";
 import { useGame } from "@/context/GameContext";
 import { TOOLBAR_HEIGHT } from "@/constants";
@@ -16,12 +17,14 @@ export type Props = {
   headingText: string;
   showInstructions: boolean;
   showInput: boolean;
+  showAttempts: boolean;
 };
 
 const LevelLayout: React.FC<Props> = ({
   headingText,
   showInstructions,
   showInput,
+  showAttempts,
   children,
 }) => {
   const game = useGame();
@@ -50,6 +53,7 @@ const LevelLayout: React.FC<Props> = ({
         {showInput && <StepValidation />}
         {children}
       </Container>
+      {showAttempts && <Text>Remaining Attempts: {game.attempts} /3 </Text>}
     </Box>
   );
 };

--- a/client/src/components/LevelLayout.tsx
+++ b/client/src/components/LevelLayout.tsx
@@ -7,7 +7,6 @@ import {
   Spacer,
   Text,
 } from "@chakra-ui/react";
-import { extendTheme } from "@chakra-ui/react";
 import { useGame } from "@/context/GameContext";
 import { TOOLBAR_HEIGHT } from "@/constants";
 import BoxesContainer from "./BoxesContainer";
@@ -62,10 +61,9 @@ const LevelLayout: React.FC<Props> = ({
           alignItems="center"
           bg="gray.200"
           p={4}
-          borderWidth="1px"
           borderRadius="lg"
         >
-          {showAttempts && <Text>Remaining Attempts: {game.attempts} /3 </Text>}
+          {showAttempts && <Text>Remaining Attempts: {game.attempts}/3 </Text>}
         </Box>
       </Flex>
     </Box>

--- a/client/src/components/LevelLayout.tsx
+++ b/client/src/components/LevelLayout.tsx
@@ -57,14 +57,15 @@ const LevelLayout: React.FC<Props> = ({
       </Container>
       <Flex>
         <Spacer />
-        <Box
-          alignItems="center"
-          bg="gray.200"
-          p={4}
-          borderRadius="lg"
-        >
-          {showAttempts && <Text>Remaining Attempts: {game.attempts}/3 </Text>}
-        </Box>
+        {showAttempts &&  
+          <Box
+            alignItems="center"
+            bg="gray.200"
+            p={4}
+            borderRadius="lg"
+          >
+           <Text>Remaining Attempts: {game.attempts}/3 </Text>
+        </Box>}
       </Flex>
     </Box>
   );

--- a/client/src/components/LevelLayout.tsx
+++ b/client/src/components/LevelLayout.tsx
@@ -7,6 +7,7 @@ import {
   Spacer,
   Text,
 } from "@chakra-ui/react";
+import { extendTheme } from "@chakra-ui/react"
 import { useGame } from "@/context/GameContext";
 import { TOOLBAR_HEIGHT } from "@/constants";
 import BoxesContainer from "./BoxesContainer";
@@ -53,7 +54,12 @@ const LevelLayout: React.FC<Props> = ({
         {showInput && <StepValidation />}
         {children}
       </Container>
-      {showAttempts && <Text>Remaining Attempts: {game.attempts} /3 </Text>}
+      <Flex>
+        <Spacer />
+        <Box display="flex" alignItems="center" bg="gray.200" p={4} borderWidth='1px' borderRadius='lg'>
+          {showAttempts && <Text>Remaining Attempts: {game.attempts} /3 </Text>}
+        </Box>
+      </Flex>
     </Box>
   );
 };

--- a/client/src/components/LevelLayout.tsx
+++ b/client/src/components/LevelLayout.tsx
@@ -57,15 +57,11 @@ const LevelLayout: React.FC<Props> = ({
       </Container>
       <Flex>
         <Spacer />
-        {showAttempts &&  
-          <Box
-            alignItems="center"
-            bg="gray.200"
-            p={4}
-            borderRadius="lg"
-          >
-           <Text>Remaining Attempts: {3-game.attempts}/3 </Text>
-        </Box>}
+        {showAttempts && (
+          <Box alignItems="center" bg="gray.200" p={4} borderRadius="lg">
+            <Text>Remaining Attempts: {3 - game.attempts}/3 </Text>
+          </Box>
+        )}
       </Flex>
     </Box>
   );

--- a/client/src/components/LevelLayout.tsx
+++ b/client/src/components/LevelLayout.tsx
@@ -58,7 +58,7 @@ const LevelLayout: React.FC<Props> = ({
       <Flex>
         <Spacer />
         {showAttempts && (
-          <Box alignItems="center" bg="gray.200" p={4} borderRadius="lg">
+          <Box bg="gray.200" p={4} borderRadius="lg">
             <Text>Remaining Attempts: {3 - game.attempts}/3 </Text>
           </Box>
         )}

--- a/client/src/components/LevelLayout.tsx
+++ b/client/src/components/LevelLayout.tsx
@@ -59,7 +59,6 @@ const LevelLayout: React.FC<Props> = ({
       <Flex>
         <Spacer />
         <Box
-          display="flex"
           alignItems="center"
           bg="gray.200"
           p={4}

--- a/client/src/components/LevelLayout.tsx
+++ b/client/src/components/LevelLayout.tsx
@@ -7,7 +7,7 @@ import {
   Spacer,
   Text,
 } from "@chakra-ui/react";
-import { extendTheme } from "@chakra-ui/react"
+import { extendTheme } from "@chakra-ui/react";
 import { useGame } from "@/context/GameContext";
 import { TOOLBAR_HEIGHT } from "@/constants";
 import BoxesContainer from "./BoxesContainer";
@@ -44,8 +44,10 @@ const LevelLayout: React.FC<Props> = ({
           <Button onClick={() => game.jumpToLevel(game.level + 1)}>
             Next Level
           </Button>
-        ) : game.stepIndex !== game.steps.length - 1 && (
-          <Button onClick={game.nextStep}>Next Step</Button>
+        ) : (
+          game.stepIndex !== game.steps.length - 1 && (
+            <Button onClick={game.nextStep}>Next Step</Button>
+          )
         )}
       </Flex>
       <Container centerContent>
@@ -56,7 +58,14 @@ const LevelLayout: React.FC<Props> = ({
       </Container>
       <Flex>
         <Spacer />
-        <Box display="flex" alignItems="center" bg="gray.200" p={4} borderWidth='1px' borderRadius='lg'>
+        <Box
+          display="flex"
+          alignItems="center"
+          bg="gray.200"
+          p={4}
+          borderWidth="1px"
+          borderRadius="lg"
+        >
           {showAttempts && <Text>Remaining Attempts: {game.attempts} /3 </Text>}
         </Box>
       </Flex>

--- a/client/src/context/GameContext.tsx
+++ b/client/src/context/GameContext.tsx
@@ -202,8 +202,8 @@ export const GameProvider: React.FC = ({ children }) => {
   }
 
   function hasSeenLevel(lastLevel: number) {
-      return lastLevel < maxLevelSeen;
-    }
+    return lastLevel < maxLevelSeen;
+  }
 
   function jumpToLevel(dest: number) {
     const { start, nums, min, max } = LEVELS[dest];
@@ -215,7 +215,7 @@ export const GameProvider: React.FC = ({ children }) => {
     setValues({});
     setCorrect({});
     if (dest > maxLevelSeen) {
-        setMaxLevelSeen(dest);
+      setMaxLevelSeen(dest);
     }
   }
 


### PR DESCRIPTION
In order to show attempts on Levels 2-5, I added a new props called `showAttempts` to `/LevelLayout`, which shows the attempts field from `/GameContext`. This props is only showed on Levels 2-5. I also styled it as follows:

![image](https://user-images.githubusercontent.com/43801999/153732223-9cf136a3-e5b6-417e-903d-17edbfbd9f41.png)
