### PR TITLE
Stop interval from initializing and clearing on every render

### DIFF
--- a/client/src/components/Timer.tsx
+++ b/client/src/components/Timer.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useState, useMemo } from "react";
 import { useGame } from "@/context/GameContext";
 import { Box } from "@chakra-ui/react";
 
@@ -8,11 +8,7 @@ const Timer: React.FC<TimerProps> = () => {
   const [secondsElapsed, setSecondsElapsed] = useState(0);
   const game = useGame();
 
-  const tick = () => {
-    setSecondsElapsed(secondsElapsed + 1);
-  };
-
-  function getTime() {
+  const time = useMemo(() => {
     let totalSeconds = secondsElapsed;
     let hrs = Math.floor(totalSeconds / 3600);
     totalSeconds %= 3600;
@@ -22,7 +18,7 @@ const Timer: React.FC<TimerProps> = () => {
     return `${hrs.toString().padStart(2, "0")}:${mins
       .toString()
       .padStart(2, "0")}:${secs.toString().padStart(2, "0")}`;
-  }
+  }, [secondsElapsed]);
 
   function reset() {
     setSecondsElapsed(0);
@@ -33,11 +29,14 @@ const Timer: React.FC<TimerProps> = () => {
   }, [game.level]);
 
   useEffect(() => {
-    const timerId = setInterval(() => tick(), 1000);
+    const timerId = setInterval(
+      () => setSecondsElapsed((prev) => prev + 1),
+      1000
+    );
     return () => clearInterval(timerId);
-  }, [secondsElapsed]);
+  }, [setSecondsElapsed]);
 
-  return <Box>{getTime()}</Box>;
+  return <Box>{time}</Box>;
 };
 
 export default Timer;


### PR DESCRIPTION
This PR improves the performance of the timer component by removing unnecessary initializations and destructions of the interval object. Previously, this is what happened:

1. `useEffect` runs
2. Sets up an interval
3. Calls `tick()`
4. `tick()` updates the `secondsElapsed`
5. This causes `useEffect` to run again (before running again it executes its cleanup routine)
6. We've got a big loop

We can see what's going on by adding some log statements:

```jsx
useEffect(() => {
  const timerId = setInterval(() => {
    console.log("Tick ", timerId);
    tick();
  }, 1000);
  console.log("Creating interval ", timerId);
  return () => {
    console.log("Clearing interval ", timerId);
    clearInterval(timerId);
  };
}, [secondsElapsed]);
```
And this is the output:
![image](https://user-images.githubusercontent.com/43855680/153767593-c2881e2b-5abf-48c9-9b17-6b3d5466ecf7.png)

To fix this, instead of reading the `secondsElapsed` value, we can use the value provided by the `setSecondsElapsed` function which is the current value and increment that by 1. This removes any dependency on the `secondsElapsed` value which means that the `useEffect` hook will not run every time the `secondsElapsed` value is changed. 

Adding the same logs: 
```jsx
useEffect(() => {
  const timerId = setInterval(() => {
    console.log("tick ", timerId);
    setSecondsElapsed((prev) => prev + 1);
  }, 1000);
  console.log("Creating interval ", timerId);
  return () => {
    console.log("Clearing interval ", timerId);
    clearInterval(timerId);
  };
}, [setSecondsElapsed]);
```

We can see that the interval is only created once and not cleared on each render.

![image](https://user-images.githubusercontent.com/43855680/153767811-17cd0acb-9611-47ae-b72d-57fe6237e315.png)

Note that there are 5 intervals because all 5 levels are rendering behind `Tabs` component. 

I also wrapped the conversion of `secondsElapsed` to a readable string in `useMemo`. Is this necessary? Probably not. 