### PR TITLE
Step index bug fix & Correct toast success message display

### DIFF
--- a/client/src/components/LevelLayout.tsx
+++ b/client/src/components/LevelLayout.tsx
@@ -44,7 +44,8 @@ const LevelLayout: React.FC<Props> = ({
   const toast = useToast();
 
   function didWin() {
-    if (game.stepIndex === game.steps.length - 2) {
+    if ((game.stepIndex === game.steps.length - 2 && game.level === 0)
+        || (game.stepIndex === game.steps.length - 2 && game.level > 0 && game.correct[0])) {
       toast({
         title: "Good job!",
         description: `You've completed level ${game.level + 1}`,

--- a/client/src/context/GameContext.tsx
+++ b/client/src/context/GameContext.tsx
@@ -21,25 +21,25 @@ const LEVELS: LevelConfig[] = [
     start: 0,
     min: 1,
     max: 20,
-    nums: 2,
+    nums: 10,
   },
   {
     start: 0,
     min: 1,
     max: 20,
-    nums: 2,
+    nums: 10,
   },
   {
     start: 0,
     min: 1,
     max: 50,
-    nums: 2,
+    nums: 20,
   },
   {
     start: 0,
     min: 1,
     max: 100,
-    nums: 2,
+    nums: 50,
   },
 ];
 interface ContextType {

--- a/client/src/context/GameContext.tsx
+++ b/client/src/context/GameContext.tsx
@@ -21,25 +21,25 @@ const LEVELS: LevelConfig[] = [
     start: 0,
     min: 1,
     max: 20,
-    nums: 10,
+    nums: 2,
   },
   {
     start: 0,
     min: 1,
     max: 20,
-    nums: 10,
+    nums: 2,
   },
   {
     start: 0,
     min: 1,
     max: 50,
-    nums: 20,
+    nums: 2,
   },
   {
     start: 0,
     min: 1,
     max: 100,
-    nums: 50,
+    nums: 2,
   },
 ];
 interface ContextType {
@@ -162,6 +162,7 @@ export const GameProvider: React.FC = ({ children }) => {
           setStepIndex(stepIndex + 1);
         }
 
+        if (stepIndex < steps.length - 2) {
         // determine which input's should remain constant for the next step
         const persistentValues = steps[stepIndex + 2].value.reduce<
           Record<number, string>
@@ -182,6 +183,7 @@ export const GameProvider: React.FC = ({ children }) => {
             return { ...accumulator, [key]: true };
           }, {})
         );
+        }
 
         setCorrect({});
       } else {


### PR DESCRIPTION
The purpose of this PR is to correct a bug where the success toast message didn't show up correctly at the end of each level. The fixes in this PR ensure that the player's guess is correct before displaying a success toast.