### PR TITLE
fixed issue where confetti doesn't show at end of last level

### DIFF
--- a/client/src/components/LevelLayout.tsx
+++ b/client/src/components/LevelLayout.tsx
@@ -93,11 +93,15 @@ const LevelLayout: React.FC<Props> = ({
         <Button mr={4} onClick={game.prevStep}>
           Previous Step
         </Button>
-        {game.stepIndex === game.steps.length - 1 && game.level < 5 - 1 ? (
+        {game.stepIndex === game.steps.length - 1 && game.level <= 5 - 1 ? (
           <>
-            <Button onClick={() => game.jumpToLevel(game.level + 1)}>
-              Next Level
-            </Button>
+            {game.stepIndex === game.steps.length - 1 && game.level < 5 - 1 ? (
+                <Button onClick={() => game.jumpToLevel(game.level + 1)}>
+                Next Level
+              </Button>
+            ) : (
+                <></>
+            )}
             <Confetti recycle={false} />
           </>
         ) : (

--- a/client/src/components/LevelLayout.tsx
+++ b/client/src/components/LevelLayout.tsx
@@ -44,8 +44,12 @@ const LevelLayout: React.FC<Props> = ({
   const toast = useToast();
 
   function didWin() {
-    if ((game.stepIndex === game.steps.length - 2 && game.level === 0)
-        || (game.stepIndex === game.steps.length - 2 && game.level > 0 && game.correct[0])) {
+    if (
+      (game.stepIndex === game.steps.length - 2 && game.level === 0) ||
+      (game.stepIndex === game.steps.length - 2 &&
+        game.level > 0 &&
+        game.correct[0])
+    ) {
       toast({
         title: "Good job!",
         description: `You've completed level ${game.level + 1}`,
@@ -95,12 +99,10 @@ const LevelLayout: React.FC<Props> = ({
         </Button>
         {game.stepIndex === game.steps.length - 1 && game.level <= 5 - 1 ? (
           <>
-            {game.stepIndex === game.steps.length - 1 && game.level < 5 - 1 ? (
-                <Button onClick={() => game.jumpToLevel(game.level + 1)}>
+            {game.stepIndex === game.steps.length - 1 && game.level < 5 - 1 && (
+              <Button onClick={() => game.jumpToLevel(game.level + 1)}>
                 Next Level
               </Button>
-            ) : (
-                <></>
             )}
             <Confetti recycle={false} />
           </>


### PR DESCRIPTION
Added a conditional statement in LevelLayout to ensure that confetti shows on final level. Since the Confetti component was placed inside the conditional that determines whether or the "Next Level" button is rendered, the Confetti wasn't being rendered on the last level. Adding a nested conditional ensures that the decision to render each is isolated.