### PR TITLE
Add client-to-server logging by calling the logging endpoints

### DIFF
--- a/client/src/components/Header.tsx
+++ b/client/src/components/Header.tsx
@@ -16,6 +16,7 @@ import Level4 from "@/components/Level4";
 import Level5 from "@/components/Level5";
 import { useGame } from "@/context/GameContext";
 import { useNavigate } from "react-router";
+import { logActionToServer } from "@/lib/logger";
 
 export type Props = {};
 
@@ -26,6 +27,7 @@ const Header = () => {
   const navigate = useNavigate();
   const routeChange = () => {
     let path = "/";
+    logActionToServer("EXIT", {});
     navigate(path);
   };
 

--- a/client/src/components/Timer.tsx
+++ b/client/src/components/Timer.tsx
@@ -5,11 +5,10 @@ import { Box, BoxProps } from "@chakra-ui/react";
 export type TimerProps = {} & BoxProps;
 
 const Timer: React.FC<BoxProps> = ({ ...rest }) => {
-  const [secondsElapsed, setSecondsElapsed] = useState(0);
   const game = useGame();
 
   const time = useMemo(() => {
-    let totalSeconds = secondsElapsed;
+    let totalSeconds = game.secondsElapsed;
     let hrs = Math.floor(totalSeconds / 3600);
     totalSeconds %= 3600;
     let mins = Math.floor(totalSeconds / 60);
@@ -18,23 +17,7 @@ const Timer: React.FC<BoxProps> = ({ ...rest }) => {
     return `${hrs.toString().padStart(2, "0")}:${mins
       .toString()
       .padStart(2, "0")}:${secs.toString().padStart(2, "0")}`;
-  }, [secondsElapsed]);
-
-  function reset() {
-    setSecondsElapsed(0);
-  }
-
-  useEffect(() => {
-    reset();
-  }, [game.level]);
-
-  useEffect(() => {
-    const timerId = setInterval(
-      () => setSecondsElapsed((prev) => prev + 1),
-      1000
-    );
-    return () => clearInterval(timerId);
-  }, []);
+  }, [game.secondsElapsed]);
 
   return <Box {...rest}>{time}</Box>;
 };

--- a/client/src/context/GameContext.tsx
+++ b/client/src/context/GameContext.tsx
@@ -1,6 +1,13 @@
-import React, { createContext, useContext, useState, useMemo } from "react";
+import React, {
+  createContext,
+  useContext,
+  useState,
+  useMemo,
+  useEffect,
+} from "react";
 import generateSteps, { Step } from "../lib/mergeSort";
 import useAudio from "../hooks/useAudio";
+import { Action, logActionToServer } from "@/lib/logger";
 
 const ATTEMPTS = 3;
 
@@ -59,6 +66,7 @@ interface ContextType {
   values: Record<number, string>;
   correct: Record<number, boolean>;
   readOnly: Record<number, boolean>;
+  secondsElapsed: number;
 }
 
 interface Options {
@@ -102,6 +110,7 @@ export const GameProvider: React.FC = ({ children }) => {
   const [values, setValues] = useState<Record<number, string>>({});
   const [correct, setCorrect] = useState<Record<number, boolean>>({});
   const [readOnly, setReadOnly] = useState<Record<number, boolean>>({});
+  const [secondsElapsed, setSecondsElapsed] = useState<number>(0);
 
   const inputCorrectSound = useAudio("shortSuccess.mp3");
   const nextLevelSound = useAudio("celebration.mp3");
@@ -115,6 +124,14 @@ export const GameProvider: React.FC = ({ children }) => {
   );
 
   const currStep = steps[stepIndex];
+
+  useEffect(() => {
+    const timerId = setInterval(
+      () => setSecondsElapsed((prev) => prev + 1),
+      1000
+    );
+    return () => clearInterval(timerId);
+  }, []);
 
   function handleInput(index: number, value: string) {
     // Avoid index out of bounds error, should never have to check
@@ -163,26 +180,26 @@ export const GameProvider: React.FC = ({ children }) => {
         }
 
         if (stepIndex < steps.length - 2) {
-        // determine which input's should remain constant for the next step
-        const persistentValues = steps[stepIndex + 2].value.reduce<
-          Record<number, string>
-        >((acc, val, index) => {
-          console.log(val);
-          if (steps[stepIndex + 1].value.includes(val)) {
-            acc[index] = val.toString();
+          // determine which input's should remain constant for the next step
+          const persistentValues = steps[stepIndex + 2].value.reduce<
+            Record<number, string>
+          >((acc, val, index) => {
+            console.log(val);
+            if (steps[stepIndex + 1].value.includes(val)) {
+              acc[index] = val.toString();
+              return acc;
+            }
             return acc;
-          }
-          return acc;
-        }, {});
+          }, {});
 
-        setValues(persistentValues);
+          setValues(persistentValues);
 
-        // all of the persistent values should be read only
-        setReadOnly(
-          Object.keys(persistentValues).reduce((accumulator, key) => {
-            return { ...accumulator, [key]: true };
-          }, {})
-        );
+          // all of the persistent values should be read only
+          setReadOnly(
+            Object.keys(persistentValues).reduce((accumulator, key) => {
+              return { ...accumulator, [key]: true };
+            }, {})
+          );
         }
 
         setCorrect({});
@@ -204,11 +221,18 @@ export const GameProvider: React.FC = ({ children }) => {
     setStepIndex(0);
     setAttempts(0);
     setValues({});
+    setSecondsElapsed(0);
     setCorrect({});
+    logActionToServer("RESTART", { level: level + 1 });
   }
 
   function hasSeenLevel(lastLevel: number) {
     return lastLevel < maxLevelSeen;
+  }
+
+  function logNextLevelAction(level: number) {
+    const action = `FINISH_LEVEL_${level}` as Action;
+    logActionToServer(action, { duration: secondsElapsed });
   }
 
   function jumpToLevel(dest: number) {
@@ -216,7 +240,10 @@ export const GameProvider: React.FC = ({ children }) => {
     setStepIndex(start);
     setNumElems(nums);
     setMinMax([min, max]);
+    logNextLevelAction(dest);
+
     setLevel(dest);
+    setSecondsElapsed(0);
     setAttempts(0);
     setValues({});
     setCorrect({});
@@ -244,6 +271,7 @@ export const GameProvider: React.FC = ({ children }) => {
         values,
         correct,
         readOnly,
+        secondsElapsed,
       }}
     >
       {children}

--- a/client/src/lib/logger.ts
+++ b/client/src/lib/logger.ts
@@ -1,0 +1,14 @@
+import axios from "axios";
+
+export type Action =
+  | "FINISH_LEVEL_1"
+  | "FINISH_LEVEL_2"
+  | "FINISH_LEVEL_3"
+  | "FINISH_LEVEL_4"
+  | "FINISH_LEVEL_5"
+  | "EXIT"
+  | "RESTART";
+
+export function logActionToServer(action: Action, payload: any): void {
+  axios.post("/api/events/", { action, payload });
+}

--- a/server/src/interfaces/Action.ts
+++ b/server/src/interfaces/Action.ts
@@ -1,0 +1,8 @@
+export type Action =
+  | "FINISH_LEVEL_1"
+  | "FINISH_LEVEL_2"
+  | "FINISH_LEVEL_3"
+  | "FINISH_LEVEL_4"
+  | "FINISH_LEVEL_5"
+  | "EXIT"
+  | "RESTART";

--- a/server/src/interfaces/Event.ts
+++ b/server/src/interfaces/Event.ts
@@ -1,5 +1,8 @@
+import { Action } from "./Action";
+
 export interface Event {
   timestamp: string;
   id: string;
-  action: string;
+  action: Action;
+  payload: any;
 }

--- a/server/src/lib/event-logger.ts
+++ b/server/src/lib/event-logger.ts
@@ -3,18 +3,19 @@ import { getId } from "./id";
 import { Event } from "../interfaces";
 import path from "path";
 import { Request } from "express";
+import { Action } from "../interfaces/Action";
 
 const folderpath = path.join(__dirname, "..", "..", "data");
 
 const filepath = path.join(folderpath, "events.log");
 
-export function log(req: Request, action: string) {
-  const id = getId(req);
+export function log(id: string, action: Action, payload: any) {
   const timestamp = Date.now().toString();
   const event: Event = {
     id,
     timestamp,
     action,
+    payload,
   };
   if (!fs.existsSync(filepath)) {
     fs.mkdirSync(folderpath, { recursive: true });
@@ -30,7 +31,7 @@ export interface GetOptions {
   actions?: string[];
 }
 
-function getLogs(options?: GetOptions) {
+function get(options?: GetOptions) {
   const { start, end, actions } = options || {};
 
   const rawData = fs.readFileSync(filepath, "utf-8");
@@ -52,12 +53,6 @@ function getLogs(options?: GetOptions) {
       return true;
     });
   return lines;
-}
-
-export function get(req: Request, options?: GetOptions) {
-  const id = getId(req);
-  const logs = getLogs(options).filter((log) => log.id === id);
-  return logs;
 }
 
 export default {

--- a/server/src/routes/events-router.ts
+++ b/server/src/routes/events-router.ts
@@ -1,15 +1,16 @@
 import { Router } from "express";
+import { Action } from "../interfaces/Action";
 import eventLoggger, { log } from "../lib/event-logger";
+import { getId } from "../lib/id";
 
 const router = Router();
 
-// Returns logs corresponding to requesting agent
 router.get("/", (req, res) => {
-  const actions = req.query.actions as string[];
+  const actions = req.query.actions as Action[];
   const start = req.query.start as string;
   const end = req.query.end as string;
 
-  let _actions: string[] = [];
+  let _actions: Action[] = [];
   if (actions instanceof Array) {
     _actions = actions;
   }
@@ -28,7 +29,7 @@ router.get("/", (req, res) => {
     _end = new Date(end);
   }
 
-  const logs = eventLoggger.get(req, {
+  const logs = eventLoggger.get({
     actions: _actions,
     start: _start,
     end: _end,
@@ -38,8 +39,10 @@ router.get("/", (req, res) => {
 
 // Logs a new event
 router.post("/", (req, res) => {
-  const action = req.body.action as string;
-  log(req, action);
+  const id = getId(req);
+  const action = req.body.action as Action;
+  const payload = req.body.payload;
+  log(id, action, payload);
   return res.status(200).send();
 });
 


### PR DESCRIPTION
# Changes
- Create an interface for `Action` and add `payload` to `Event`
- Add logging calls from client for completing levels, exit, and restart

# Logs Created
`{"id":"bab5a874894d6c1fd4376f2ff0e5856f","timestamp":"1647550705829","action":"FINISH_LEVEL_1","payload":{"duration":6}}
{"id":"bab5a874894d6c1fd4376f2ff0e5856f","timestamp":"1647550716143","action":"RESTART","payload":{"level":2}}
{"id":"bab5a874894d6c1fd4376f2ff0e5856f","timestamp":"1647550728314","action":"EXIT","payload":{}}
`
