### PR TITLE
Serve client application on any URL

### DIFF
--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -32,6 +32,10 @@ if (process.env.NODE_ENV === "production") {
 
 app.use(express.static(staticPath));
 
+app.get("/*", (req, res) => {
+  res.sendFile(path.join(staticPath, "index.html"));
+});
+
 // Use all application routes behind the /api route
 app.use("/api", routes);
 


### PR DESCRIPTION
This PR updates the express server to serve the client application for any route. This fixes the issue of a 404 not found error when trying to navigate to a client side route.